### PR TITLE
Fix threat model configuration loading

### DIFF
--- a/mcp-server/src/server.py
+++ b/mcp-server/src/server.py
@@ -367,7 +367,8 @@ class MCPServer:
             self.grid_monitor = GridMonitor(self.federate)
             
             # Initialize threat validator
-            self.threat_validator = ThreatModelValidator('config/threat_model.yaml')
+            config_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'config')
+            self.threat_validator = ThreatModelValidator(os.path.join(config_dir, 'threat_model.yaml'))
             
             # Initialize AI strategist
             try:

--- a/mcp-server/src/utils/validation.py
+++ b/mcp-server/src/utils/validation.py
@@ -52,11 +52,14 @@ class ThreatModelValidator:
         try:
             if os.path.exists(self.config_path):
                 with open(self.config_path, 'r') as f:
-                    file_constraints = yaml.safe_load(f)
-                    # Merge with defaults
+                    file_constraints = yaml.safe_load(f) or {}
+                    # Merge with defaults, handling both dict and list sections
                     for section, values in file_constraints.items():
                         if section in default_constraints:
-                            default_constraints[section].update(values)
+                            if isinstance(default_constraints[section], dict) and isinstance(values, dict):
+                                default_constraints[section].update(values)
+                            else:
+                                default_constraints[section] = values
                         else:
                             default_constraints[section] = values
         except Exception as e:


### PR DESCRIPTION
## Summary
- ensure ThreatModelValidator loads configuration from correct path
- handle list-based sections when merging YAML constraints with defaults

## Testing
- `python -m py_compile mcp-server/src/server.py mcp-server/src/utils/validation.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689533b2f3d48324a342e077ee399db9